### PR TITLE
Fix possible error in logic and sed cleanup

### DIFF
--- a/PXC/slave_manager.sh
+++ b/PXC/slave_manager.sh
@@ -59,8 +59,7 @@ MYSQL="`which mysql` --connect_timeout=10 -B"
 
 # retrieve the slave status and set variables
 get_slave_status() {
-	eval `$MYSQL -e "show slave status\G" 2> /tmp/mysql_error | grep -v Last \
-		| grep -v '\*\*\*\*' \| sed -e ':a' -e 'N' -e '$!ba' -e 's/,\n/, /g' \
+	eval `$MYSQL -e "show slave status\G" 2> /tmp/mysql_error | grep Slave_S \
 		| sed -e 's/^\s*//g' -e 's/: /=/g' -e 's/\(.*\)=\(.*\)$/\1='"'"'\2'"'"'/g'`
 
 	if [ "$(grep -c ERROR /tmp/mysql_error)" -gt 0 ]; then
@@ -82,9 +81,9 @@ is_replication_ok() {
 	get_slave_status
 	stateOk=$(echo $Slave_IO_State | grep -ci connect) # anything with connect in Slave_IO_State is bad
 	if [[ $Slave_IO_Running == "Yes" && $Slave_SQL_Running == "Yes" && $stateOk -eq 0 ]]; then
-		echo 1
-	else
 		echo 0
+	else
+		echo 1
 	fi
 }
 
@@ -100,7 +99,7 @@ setup_replication() {
 		
 		sleep 10  # Give some time for replication to settle
 		
-		if [ "$(is_replication_ok)" -eq 1 ]; then
+		if [ "$(is_replication_ok)" -eq 0 ]; then
 			send_email "Slave $hostname master is now $master" "New slave"  
 			masterOk=1
 			break

--- a/PXC/slave_manager.sh
+++ b/PXC/slave_manager.sh
@@ -59,7 +59,7 @@ MYSQL="`which mysql` --connect_timeout=10 -B"
 
 # retrieve the slave status and set variables
 get_slave_status() {
-	eval `$MYSQL -e "show slave status\G" 2> /tmp/mysql_error | grep Slave_S \
+	eval `$MYSQL -e "show slave status\G" 2> /tmp/mysql_error | grep Slave_ \
 		| sed -e 's/^\s*//g' -e 's/: /=/g' -e 's/\(.*\)=\(.*\)$/\1='"'"'\2'"'"'/g'`
 
 	if [ "$(grep -c ERROR /tmp/mysql_error)" -gt 0 ]; then


### PR DESCRIPTION
Replaced the sed expression: since you're only accessing the variables that start with 'Slave_' it might make more sense to just look those ones up.
I also found a problem with the logic unless I am getting it wrong: is_replication_ok() returns 1 if everything is correct, and that value triggers setup_replication(). I changed the values for the output on that function and the reference inside setup_replication() as well to 0, and now the script behaves as expected.